### PR TITLE
Individual Player Logout

### DIFF
--- a/src/server/admin/gameLogin.ts
+++ b/src/server/admin/gameLogin.ts
@@ -48,7 +48,8 @@ export const gameLogin = async (req: Request, res: Response) => {
     // Are any of the controllers already logged in?
     for (const gameController of gameControllers) {
         if (thisGame.getLoggedIn(gameTeam, gameController) !== 0) {
-            res.redirect(`/index.html?error=${ALREADY_IN_TAG}`);
+            const gameControllerTexts = ['COCOM', 'JFACC', 'JFLCC', 'JFMCC', 'JFSOC'];
+            res.redirect(`/index.html?error=${ALREADY_IN_TAG}&playerType=${gameControllerTexts[gameController]}`);
             return;
         }
     }

--- a/src/server/admin/index.ts
+++ b/src/server/admin/index.ts
@@ -14,3 +14,4 @@ export * from './setAdminPassword';
 export * from './setTeamPasswords';
 export * from './toggleGameActive';
 export * from './logout';
+export * from './logoutPlayer';

--- a/src/server/admin/logoutPlayer.ts
+++ b/src/server/admin/logoutPlayer.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import { ACCESS_TAG, GAME_DOES_NOT_EXIST, LOGIN_TAG, NOT_LOGGED_IN_VALUE, SOCKET_SERVER_REDIRECT } from '../../constants';
+import { io } from '../../server';
+import { TeacherSession } from '../../types';
+import { Game } from '../classes';
+
+/**
+ * Logout a single player from a game.
+ */
+export const logoutPlayer = async (req: Request, res: Response) => {
+    // Verify Session
+    if (!req.session.ir3teacher) {
+        res.status(403).redirect(`/index.html?error=${ACCESS_TAG}`);
+        return;
+    }
+
+    // Verify Request
+    if (!req.body.gameTeam || !req.body.gameController) {
+        res.status(403).redirect('/teacher.html?logoutPlayer=failed');
+        return;
+    }
+
+    const { gameId } = req.session.ir3teacher as TeacherSession;
+
+    // Get game info
+    const thisGame = await new Game(gameId).init();
+    if (!thisGame) {
+        res.status(400).redirect(`/index.html?error=${GAME_DOES_NOT_EXIST}`);
+        return;
+    }
+
+    const { gameTeam, gameController }: LogoutPlayerRequest = req.body;
+
+    await thisGame.setLoggedIn(parseInt(gameTeam), parseInt(gameController), NOT_LOGGED_IN_VALUE);
+
+    io.sockets.to(`game${gameId}team${gameTeam}controller${gameController}`).emit(SOCKET_SERVER_REDIRECT, LOGIN_TAG);
+
+    res.redirect('/teacher.html?logoutPlayer=success');
+};
+
+/**
+ * All the values needed for request to set team passwords.
+ */
+type LogoutPlayerRequest = {
+    gameTeam: string;
+    gameController: string;
+};

--- a/src/server/pages/teacher.html
+++ b/src/server/pages/teacher.html
@@ -108,6 +108,15 @@
                 text-decoration: none;
                 user-select: none;
             }
+            Red {
+                color: red;
+            }
+            Green {
+                color: green;
+            }
+            Blue {
+                color: blue;
+            }
         </style>
     </head>
     <body>
@@ -166,6 +175,96 @@
 
         <hr />
 
+        <h3>Manually Logout Players</h3>
+        <table>
+            <tr>
+                <td><Blue>Blue Team</Blue></td>
+                <td><Red>Red Team</Red></td>
+            </tr>
+            <tr>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(0, 0)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="0" />
+                        <input type="hidden" name="gameController" value="0" />
+                        <input type="submit" name="Submit" value="COCOM" />
+                    </form>
+                </td>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(1, 0)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="1" />
+                        <input type="hidden" name="gameController" value="0" />
+                        <input type="submit" name="Submit" value="COCOM" />
+                    </form>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(0, 1)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="0" />
+                        <input type="hidden" name="gameController" value="1" />
+                        <input type="submit" name="Submit" value="JFACC" />
+                    </form>
+                </td>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(1, 1)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="1" />
+                        <input type="hidden" name="gameController" value="1" />
+                        <input type="submit" name="Submit" value="JFACC" />
+                    </form>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(0, 2)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="0" />
+                        <input type="hidden" name="gameController" value="2" />
+                        <input type="submit" name="Submit" value="JFLCC" />
+                    </form>
+                </td>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(1, 2)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="1" />
+                        <input type="hidden" name="gameController" value="2" />
+                        <input type="submit" name="Submit" value="JFLCC" />
+                    </form>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(0, 3)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="0" />
+                        <input type="hidden" name="gameController" value="3" />
+                        <input type="submit" name="Submit" value="JFMCC" />
+                    </form>
+                </td>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(1, 3)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="1" />
+                        <input type="hidden" name="gameController" value="3" />
+                        <input type="submit" name="Submit" value="JFMCC" />
+                    </form>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(0, 4)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="0" />
+                        <input type="hidden" name="gameController" value="4" />
+                        <input type="submit" name="Submit" value="JFSOC" />
+                    </form>
+                </td>
+                <td>
+                    <form name="logoutPlayer" method="post" onsubmit="return confirmLogout(1, 4)" action="/logoutPlayer">
+                        <input type="hidden" name="gameTeam" value="1" />
+                        <input type="hidden" name="gameController" value="4" />
+                        <input type="submit" name="Submit" value="JFSOC" />
+                    </form>
+                </td>
+            </tr>
+        </table>
+
+        <hr />
+
         <h3>News Alerts for this game:</h3>
 
         <table id="newsTable" border="1">
@@ -176,6 +275,27 @@
         </table>
 
         <script>
+            // function logout(gameTeamNumber, gameControllerNumber) {
+            //     const controllerTexts = ['COCOM', 'JFACC', 'JFLCC', 'JFMCC', 'JFSOC'];
+            //     const teamText = gameTeamNumber === 0 ? 'Blue' : 'Red';
+            //     const message = `Are you sure you want to logout ${teamText} ${controllerTexts[gameControllerNumber]}`;
+            //     if (confirm(message)) {
+            //         let logoutPlayer = new XMLHttpRequest();
+            //         logoutPlayer.open('POST', `/logoutPlayer?gameTeam=${gameTeamNumber}&gameController=${gameControllerNumber}`, true);
+            //         logoutPlayer.send();
+            //     }
+            // }
+
+            function confirmLogout(gameTeam, gameController) {
+                const controllerTexts = ['COCOM', 'JFACC', 'JFLCC', 'JFMCC', 'JFSOC'];
+                const teamText = gameTeam === 0 ? 'Blue' : 'Red';
+                const message = `Are you sure you want to logout ${teamText} ${controllerTexts[gameController]}`;
+                if (confirm(message)) {
+                    return true;
+                }
+                return false;
+            }
+
             function gameReset() {
                 if (confirm('ARE YOU SURE YOU WANT TO RESET THIS GAME?')) {
                     return confirm('ARE YOU EXTRA SURE? THIS WILL DELETE ALL DATA FOR THIS GAME...');
@@ -252,6 +372,15 @@
                     break;
                 case 'failed':
                     document.getElementById('ErrorTag').innerHTML = 'Failed to Update Passwords';
+                    break;
+            }
+
+            switch (getUrlParam('logoutPlayer')) {
+                case 'success':
+                    document.getElementById('SuccessTag').innerHTML = 'Successfully logged out player';
+                    break;
+                case 'failed':
+                    document.getElementById('ErrorTag').innerHTML = 'Failed to log out player';
                     break;
             }
         </script>

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -2,7 +2,7 @@ import { Request, Response, Router } from 'express';
 import path from 'path';
 import { DATABASE_TAG, LOGIN_TAG } from '../constants';
 // prettier-ignore
-import { adminLogin, dbStatus, gameAdd, gameDelete, gameLogin, gameReset, getGameActive, getGames, getNews, insertDatabaseTables, setAdminPassword, setTeamPasswords, toggleGameActive, logout } from './admin';
+import { adminLogin, dbStatus, gameAdd, gameDelete, gameLogin, gameReset, getGameActive, getGames, getNews, insertDatabaseTables, logout, logoutPlayer, setAdminPassword, setTeamPasswords, toggleGameActive } from './admin';
 
 /**
  * Express Router to handle different routes on the server.
@@ -212,5 +212,14 @@ router.post('/gameReset', async (req: Request, res: Response) => {
     } catch (error) {
         console.error(error.code);
         res.status(500).redirect('/teacher.html?gameReset=failed');
+    }
+});
+
+router.post('/logoutPlayer', async (req: Request, res: Response) => {
+    try {
+        await logoutPlayer(req, res);
+    } catch (error) {
+        console.error(error.code);
+        res.status(500).redirect('/teacher.html?playerLogout=failed');
     }
 });

--- a/src/server/socketSetup.ts
+++ b/src/server/socketSetup.ts
@@ -44,6 +44,11 @@ export const socketSetup = async (socket: Socket) => {
     socket.join(`game${gameId}`);
     socket.join(`game${gameId}team${gameTeam}`);
 
+    // Socket Room for individual controllers (in case need to force logout)
+    for (const gameController of gameControllers) {
+        socket.join(`game${gameId}team${gameTeam}controller${gameController}`);
+    }
+
     // Add socketId to session information
     socket.handshake.session.socketId = socket.id;
 


### PR DESCRIPTION
New form on the teacher page to reset individual controllers for each team to be logged out.

Typical use case = only 1 member of a team is getting 'already logged in'
Previous solution was to 'deactivate -> reactivate' the game, which forces all members from both teams out of the game to log in again.
New solution (this PR) -> teacher can click individual team/controller buttons to reset logged in status

ex: Teacher would click 'blue COCOM' button if that individual was getting the 'already logged in' message.

See pivotal for more details.